### PR TITLE
Add space-age as optional dependency to avoid breaking it if present

### DIFF
--- a/pixeltorio_base_ent/data.lua
+++ b/pixeltorio_base_ent/data.lua
@@ -559,6 +559,9 @@ data.raw["corpse"]["behemoth-worm-corpse-burrowed"].ground_patch_decay=nil
 for i,deconame in pairs(data.raw["optimized-decorative"]) do
     for j,decopic in ipairs(deconame.pictures) do
         decopic.filename="__pixeltorio_base_ent__/graphics/tileset/bigdummy.png"
+        decopic.position={0,0}
+        decopic.x=0
+        decopic.y=0
     end
 end
 

--- a/pixeltorio_base_ent/info.json
+++ b/pixeltorio_base_ent/info.json
@@ -4,6 +4,6 @@
   "title": "Pixeltorio8 - ASCII graphics!",
   "author": "Kabury",
   "factorio_version": "2.0",
-  "dependencies": ["base >= 2.0"],
+  "dependencies": ["base >= 2.0", "? space-age"],
   "description": "This mod changes the base game entities graphics to an ASCII style!"
 }


### PR DESCRIPTION
Space Age kind of falls over if some base game graphic data was modified in a way it didn't expect. This adds it as an optional dependency to ensure it gets a chance to do what it needs with that data first, before this mod mangles it.

Also, some of the sprites used by its decoratives seem to have positions outside the bounds of the 2048x2048 replacement sheet, `bigdummy.png`, causing another error on load. Since the empty sheet looks the same everywhere anyway and none of the sprites are *individually* too large to fit, setting all of their positions on the sheet to `{0, 0}` seems to fix that too.