### PR TITLE
Rolling stock improvements

### DIFF
--- a/pixeltorio_base_ent/data.lua
+++ b/pixeltorio_base_ent/data.lua
@@ -127,16 +127,46 @@ local function helper(arg)
         end
     end
     local layerstable = {}
-    local cx = (x-1)/2
-    local cy = (y-1)/2
+    offx = offx - (x-1)/2
+    offy = offy - (y-1)/2
     local i = 1
     for char in string.gmatch(chars,'([^,]+)') do
-        local xcord=(i-1)%x - cx + offx
-        local ycord=math.floor((i-1)/x) - cy + offy - offz
+        local xcord=(i-1)%x + offx
+        local ycord=math.floor((i-1)/x) + offy
         if char == " " then char = "≞" end
         if b == " " then b = "≞" end
-        layerstable[i*2-1] =   {filename = "__pixeltorio_base_ent__/graphics/tileset/" .. b .. ".png",width=resolution*cwidth,height=resolution*cheight,scale=32/cres,tint=btint[i],shift={xcord,ycord},variation_count=var,direction_count=dir,frame_count=fram,priority="extra-high-no-scale",animation_speed=1/180}
-        layerstable[i*2] = {filename = "__pixeltorio_base_ent__/graphics/tileset/" .. char .. ".png",width=resolution*cwidth,height=resolution*cheight,scale=32/cres,tint=ftint[i],shift={xcord,ycord},variation_count=var,direction_count=dir,frame_count=fram,priority="extra-high-no-scale",animation_speed=1/180,apply_runtime_tint=arg.apply_runtime_tint}
+        -- individual filenames and shifts for each rotation frame
+        local filename_bg, filename, shift
+        local filenames_bg, filenames, frames = {}, {}, {}
+        for j=1,dir do
+            local o = (j-1)/dir
+            filenames_bg[j] = "__pixeltorio_base_ent__/graphics/tileset/" .. rotated_glyph(b, o) .. ".png"
+            filenames[j] = "__pixeltorio_base_ent__/graphics/tileset/" .. rotated_glyph(char, o) .. ".png"
+            local fshift = rotated_shift({ xcord, ycord }, o)
+            fshift[2] = fshift[2] - offz
+            frames[j] = {
+                shift = fshift,
+                x = 0, y = 0, -- All sprites are single frames
+            }
+        end
+        if dir == 1 then
+            filename_bg = filenames_bg[1]
+            filename = filenames[1]
+            shift = frames[1].shift
+            filenames_bg = nil
+            filenames = nil
+            frames = nil
+        end
+        layerstable[i*2-1] =   {filename=filename_bg,filenames=filenames_bg,frames=frames,width=resolution*cwidth,height=resolution*cheight,scale=32/cres,tint=btint[i],shift=shift,variation_count=var,direction_count=dir,frame_count=fram,priority="extra-high-no-scale",animation_speed=1/180}
+        layerstable[i*2] = {filename=filename,filenames=filenames,frames=frames,width=resolution*cwidth,height=resolution*cheight,scale=32/cres,tint=ftint[i],shift=shift,variation_count=var,direction_count=dir,frame_count=fram,priority="extra-high-no-scale",animation_speed=1/180,apply_runtime_tint=arg.apply_runtime_tint}
+        -- Individual sprite graphics
+        layerstable[i*2-1].lines_per_file = 1
+        layerstable[i*2-1].line_length = 1
+        layerstable[i*2].lines_per_file = 1
+        layerstable[i*2].line_length = 1
+        -- Thanks to a more enlightened approach to asset creation, these sprites do not suffer from the usual flaws introduced by 3D rendering software
+        layerstable[i*2-1].apply_projection = false
+        layerstable[i*2].apply_projection = false
         i=i+1
     end
     return layerstable
@@ -1918,13 +1948,13 @@ data.raw["rail-chain-signal"]["rail-chain-signal"].ground_picture_set.signal_col
 data.raw["corpse"]["rail-chain-signal-remnants"].animation={layers=helper{chars="🚦",x=1,y=1,ftint={{r=1,g=0.3,b=0.5}}}}
 
 local train_wheels = {rotated={layers=helper{chars="━,━,└,┘",x=2,y=2}}}
-data.raw["locomotive"]["locomotive"].pictures={rotated={layers=helper{chars="━,━,━,━,━,╲,━,━,━,━,━,╱",x=6,y=2,offz=1,apply_runtime_tint=true}}}
+data.raw["locomotive"]["locomotive"].pictures={rotated={layers=helper{chars="╱,╲,┃,┃,┃,┃,┃,┃,┃,┃,┃,┃",x=2,y=6,offz=1,dir=36,apply_runtime_tint=true}}}
 data.raw["locomotive"]["locomotive"].wheels=train_wheels
-data.raw["cargo-wagon"]["cargo-wagon"].pictures={rotated={layers=helper{chars="W,W,W,W,W,W,W,W,W,W,W,W",x=6,y=2,offz=1,apply_runtime_tint=true}}}
-data.raw["cargo-wagon"]["cargo-wagon"].vertical_doors={layers=helper{chars="W,W,w,w,w,w,w,w,w,w,W,W",x=2,y=6,offz=1,apply_runtime_tint=true}}
-data.raw["cargo-wagon"]["cargo-wagon"].horizontal_doors={layers=helper{chars="W,w,w,w,w,W,W,w,w,w,w,W",x=6,y=2,offz=1,apply_runtime_tint=true}}
+data.raw["cargo-wagon"]["cargo-wagon"].pictures={rotated={layers=helper{chars="w,w,W,W,W,W,W,W,W,W,w,w",x=2,y=6,offz=1,dir=36,apply_runtime_tint=true}}}
+data.raw["cargo-wagon"]["cargo-wagon"].vertical_doors={layers=helper{chars="w,w,┃,┃,┃,┃,┃,┃,┃,┃,w,w",x=2,y=6,offz=1,apply_runtime_tint=true}}
+data.raw["cargo-wagon"]["cargo-wagon"].horizontal_doors={layers=helper{chars="w,━,━,━,━,w,w,━,━,━,━,w",x=6,y=2,offz=1,apply_runtime_tint=true}}
 data.raw["cargo-wagon"]["cargo-wagon"].wheels=train_wheels
-data.raw["corpse"]["cargo-wagon-remnants"].animation={layers=helper{chars="w,w,w,w,w,w,∅,∅,∅,∅,∅,∅",x=6,y=2,ftint={{r=1,g=0.3,b=0.5}}}}
+data.raw["corpse"]["cargo-wagon-remnants"].animation={layers=helper{chars="w,w,w,w,w,w,∅,∅,∅,∅,∅,∅",x=2,y=6,ftint={{r=1,g=0.3,b=0.5}}}}
 
 
 data.raw["fish"]["fish"].pictures={sheet={layers=helper{chars="🐟",x=1,y=1,btint={{r=0,g=0,b=0,a=0}}}}}

--- a/pixeltorio_base_ent/data.lua
+++ b/pixeltorio_base_ent/data.lua
@@ -62,11 +62,10 @@ local function rotated_glyph(glyph, o)
 end
 
 local tau = math.pi * 2
-local sqrt2 = math.sqrt(2)
 local cos = math.cos
 local sin = math.sin
 
--- Rather than rotating offsets in the usual fashion, we skew their positions instead. This lets sprites smoothly slide past each
+-- Rather than rotating glyph offsets in the usual fashion, we skew them instead. This lets sprites smoothly slide past each
 -- other without unsightly gaps or overlaps for diagonal orientations. Skewing is always done laterally relative to the given
 -- orientation, approaching a full grid step of skew at an offset of 45 degrees from cardinal directions. Discontinuities exist
 -- where those regions meet, but the overall result is much nicer-looking than the alternative. Horizontal skewing is used at those
@@ -80,9 +79,9 @@ local sin = math.sin
 ---@return Vector
 local function rotated_shift(shift, o)
     local x, y = shift[1], shift[2]
-    o = o % 1
-    local s, c = sin(o * tau), cos(o * tau)
-    if c*c > 0.5 then
+    o = o*tau
+    local s, c = sin(o), cos(o)
+    if c*c >= 0.5 then
         -- Skew horizontally
         return {
             (c < 0 and -1 or 1)*(x - y * s/c),

--- a/pixeltorio_base_ent/data.lua
+++ b/pixeltorio_base_ent/data.lua
@@ -9,14 +9,14 @@ function removeFirst(tbl,val)
 end
 
 function deep_tint (tabl, tint)  --thx darkfrei
-	for i,  v in pairs (tabl) do
-		if type (v) == "table" then
-			deep_tint (v, tint)
-		end
-	end
-	if tabl.picture then 
-		tabl.tint = tint
-	end
+    for i,  v in pairs (tabl) do
+        if type (v) == "table" then
+            deep_tint (v, tint)
+        end
+    end
+    if tabl.picture then
+        tabl.tint = tint
+    end
 end
 
 function helper(arg)
@@ -37,7 +37,7 @@ function helper(arg)
     if cres == nil then cres = resolution end
     allen = x*y
     if #chars == 2 then chars = string.rep(chars,allen) end
-    if #ftint == 1 then 
+    if #ftint == 1 then
         for i = 1,allen do
             ftint[i] = ftint[1]
         end
@@ -84,7 +84,7 @@ data.raw["character"]["character"].animations={
         running_with_gun={
             filename="__pixeltorio_base_ent__/graphics/tileset/character.png",width=resolution*1,height=resolution*2,scale=32/resolution,line_length=18,frame_count=1,shift={0,-1},direction_count=18
         }
-    }   
+    }
 }
 
 data.raw["accumulator"]["accumulator"].chargable_graphics={
@@ -243,7 +243,7 @@ data.raw["corpse"]["lab-remnants"].animation={layers=helper{chars="∅,∅,∅,�
 
 data.raw["beacon"]["beacon"].graphics_set={
     animation_list={
-        {animation={layers=helper{chars="b,Ɨ,b,b,Ɨ,b,b,b,b"}}}  
+        {animation={layers=helper{chars="b,Ɨ,b,b,Ɨ,b,b,b,b"}}}
     }
 }
 data.raw["corpse"]["beacon-remnants"].animation={layers=helper{chars="∅,∅,∅,∅,Ɨ,∅,∅,b,∅",ftint={{r=1,g=0.3,b=0.5}}}}

--- a/pixeltorio_base_ent/data.lua
+++ b/pixeltorio_base_ent/data.lua
@@ -1955,7 +1955,9 @@ data.raw["cargo-wagon"]["cargo-wagon"].vertical_doors={layers=helper{chars="w,w,
 data.raw["cargo-wagon"]["cargo-wagon"].horizontal_doors={layers=helper{chars="w,━,━,━,━,w,w,━,━,━,━,w",x=6,y=2,offz=1,apply_runtime_tint=true}}
 data.raw["cargo-wagon"]["cargo-wagon"].wheels=train_wheels
 data.raw["corpse"]["cargo-wagon-remnants"].animation={layers=helper{chars="w,w,w,w,w,w,∅,∅,∅,∅,∅,∅",x=2,y=6,ftint={{r=1,g=0.3,b=0.5}}}}
-
+-- I don't love how the fluid tanks look under rotation, so it might be worth adding support for "sub-sprites" that skew together uniformly for a more rigid appearance
+data.raw["fluid-wagon"]["fluid-wagon"].pictures={rotated={layers=helper{chars="◜,◝,◟,◞,◜,◝,◟,◞,◜,◝,◟,◞",x=2,y=6,offz=1,dir=36,apply_runtime_tint=true}}}
+data.raw["fluid-wagon"]["fluid-wagon"].wheels=train_wheels
 
 data.raw["fish"]["fish"].pictures={sheet={layers=helper{chars="🐟",x=1,y=1,btint={{r=0,g=0,b=0,a=0}}}}}
 

--- a/pixeltorio_base_ent/data.lua
+++ b/pixeltorio_base_ent/data.lua
@@ -58,7 +58,7 @@ local function helper(arg)
         if char == " " then char = "≞" end
         if b == " " then b = "≞" end
         layerstable[i*2-1] =   {filename = "__pixeltorio_base_ent__/graphics/tileset/" .. b .. ".png",width=resolution*cwidth,height=resolution*cheight,scale=32/cres,tint=btint[i],shift={xcord,ycord},variation_count=var,direction_count=dir,frame_count=fram,priority="extra-high-no-scale",animation_speed=1/180}
-        layerstable[i*2] = {filename = "__pixeltorio_base_ent__/graphics/tileset/" .. char .. ".png",width=resolution*cwidth,height=resolution*cheight,scale=32/cres,tint=ftint[i],shift={xcord,ycord},variation_count=var,direction_count=dir,frame_count=fram,priority="extra-high-no-scale",animation_speed=1/180}
+        layerstable[i*2] = {filename = "__pixeltorio_base_ent__/graphics/tileset/" .. char .. ".png",width=resolution*cwidth,height=resolution*cheight,scale=32/cres,tint=ftint[i],shift={xcord,ycord},variation_count=var,direction_count=dir,frame_count=fram,priority="extra-high-no-scale",animation_speed=1/180,apply_runtime_tint=arg.apply_runtime_tint}
         i=i+1
     end
     return layerstable
@@ -1839,8 +1839,13 @@ data.raw["rail-chain-signal"]["rail-chain-signal"].ground_picture_set.signal_col
 
 data.raw["corpse"]["rail-chain-signal-remnants"].animation={layers=helper{chars="🚦",x=1,y=1,ftint={{r=1,g=0.3,b=0.5}}}}
 
-
-data.raw["cargo-wagon"]["cargo-wagon"].pictures={rotated={layers=helper{chars="w,w,w,w,w,w,w,w,w,w,w,w",x=6,y=2,offz=1}}}
+local train_wheels = {rotated={layers=helper{chars="━,━,└,┘",x=2,y=2}}}
+data.raw["locomotive"]["locomotive"].pictures={rotated={layers=helper{chars="━,━,━,━,━,╲,━,━,━,━,━,╱",x=6,y=2,offz=1,apply_runtime_tint=true}}}
+data.raw["locomotive"]["locomotive"].wheels=train_wheels
+data.raw["cargo-wagon"]["cargo-wagon"].pictures={rotated={layers=helper{chars="W,W,W,W,W,W,W,W,W,W,W,W",x=6,y=2,offz=1,apply_runtime_tint=true}}}
+data.raw["cargo-wagon"]["cargo-wagon"].vertical_doors={layers=helper{chars="W,W,w,w,w,w,w,w,w,w,W,W",x=2,y=6,offz=1,apply_runtime_tint=true}}
+data.raw["cargo-wagon"]["cargo-wagon"].horizontal_doors={layers=helper{chars="W,w,w,w,w,W,W,w,w,w,w,W",x=6,y=2,offz=1,apply_runtime_tint=true}}
+data.raw["cargo-wagon"]["cargo-wagon"].wheels=train_wheels
 data.raw["corpse"]["cargo-wagon-remnants"].animation={layers=helper{chars="w,w,w,w,w,w,∅,∅,∅,∅,∅,∅",x=6,y=2,ftint={{r=1,g=0.3,b=0.5}}}}
 
 

--- a/pixeltorio_base_ent/data.lua
+++ b/pixeltorio_base_ent/data.lua
@@ -1,6 +1,6 @@
 local resolution = 32
 
-function removeFirst(tbl,val)
+local function removeFirst(tbl,val)
     for i,v in ipairs(tbl) do
         if v == val then
             return table.remove(tbl,i)
@@ -8,7 +8,7 @@ function removeFirst(tbl,val)
     end
 end
 
-function deep_tint (tabl, tint)  --thx darkfrei
+local function deep_tint (tabl, tint)  --thx darkfrei
     for i,  v in pairs (tabl) do
         if type (v) == "table" then
             deep_tint (v, tint)
@@ -19,8 +19,8 @@ function deep_tint (tabl, tint)  --thx darkfrei
     end
 end
 
-function helper(arg)
-    local chars,ftint,x,y,btint,b,offx,offy,var,dir,fram,cwidth,cheight,cres = arg.chars,arg.ftint,arg.x,arg.y,arg.btint,arg.b,arg.offx,arg.offy,arg.var,arg.dir,arg.fram,arg.cwidth,arg.cheight,arg.cres
+local function helper(arg)
+    local chars,ftint,x,y,btint,b,offx,offy,offz,var,dir,fram,cwidth,cheight,cres = arg.chars,arg.ftint,arg.x,arg.y,arg.btint,arg.b,arg.offx,arg.offy,arg.offz,arg.var,arg.dir,arg.fram,arg.cwidth,arg.cheight,arg.cres
     if chars == nil then chars = "a," end
     if b == nil then b = "background" end
     if x == nil then x = 3 end
@@ -29,13 +29,14 @@ function helper(arg)
     if btint == nil then btint = {{r=0,g=0,b=0}} end
     if offx == nil then offx = 0 end
     if offy == nil then offy = 0 end
+    if offz == nil then offz = 0 end
     if var == nil then var = 1 end
     if dir == nil then dir = 1 end
     if fram == nil then fram = 1 end
     if cwidth == nil then cwidth = 1 end
     if cheight == nil then cheight = 1 end
     if cres == nil then cres = resolution end
-    allen = x*y
+    local allen = x*y
     if #chars == 2 then chars = string.rep(chars,allen) end
     if #ftint == 1 then
         for i = 1,allen do
@@ -47,23 +48,13 @@ function helper(arg)
             btint[i] = btint[1]
         end
     end
-    layerstable = {}
+    local layerstable = {}
+    local cx = (x-1)/2
+    local cy = (y-1)/2
     local i = 1
     for char in string.gmatch(chars,'([^,]+)') do
-        xcord=(i-1)%x - 1 + offx
-        ycord=math.floor((i-1)/x) - 1 + offy
-        if x%2 == 0 then xcord = xcord + 0.5 end
-        if y%2 == 0 then ycord = ycord + 0.5 end
-        if x == 1 then xcord = xcord + 1 end
-        if y == 1 then ycord = ycord + 1 end
-        if x == 4 then xcord = xcord - 1 end
-        if y == 4 then ycord = ycord - 1 end
-        if x == 5 then xcord = xcord - 1 end
-        if y == 5 then ycord = ycord - 1 end
-        if x == 9 then xcord = xcord - 3 end
-        if y == 9 then ycord = ycord - 3 end
-        if x == 11 then xcord = xcord - 4 end
-        if y == 11 then ycord = ycord - 4 end
+        local xcord=(i-1)%x - cx + offx
+        local ycord=math.floor((i-1)/x) - cy + offy - offz
         if char == " " then char = "≞" end
         if b == " " then b = "≞" end
         layerstable[i*2-1] =   {filename = "__pixeltorio_base_ent__/graphics/tileset/" .. b .. ".png",width=resolution*cwidth,height=resolution*cheight,scale=32/cres,tint=btint[i],shift={xcord,ycord},variation_count=var,direction_count=dir,frame_count=fram,priority="extra-high-no-scale",animation_speed=1/180}
@@ -1849,8 +1840,8 @@ data.raw["rail-chain-signal"]["rail-chain-signal"].ground_picture_set.signal_col
 data.raw["corpse"]["rail-chain-signal-remnants"].animation={layers=helper{chars="🚦",x=1,y=1,ftint={{r=1,g=0.3,b=0.5}}}}
 
 
-data.raw["cargo-wagon"]["cargo-wagon"].pictures={rotated={layers=helper{chars="w,w,w,w,w,w,w,w,w,w,w,w",x=6,y=2,offx=-2,offy=-0.5}}}
-data.raw["corpse"]["cargo-wagon-remnants"].animation={layers=helper{chars="w,w,w,w,w,w,∅,∅,∅,∅,∅,∅",x=6,y=2,offx=-2,offy=-0.5,ftint={{r=1,g=0.3,b=0.5}}}}
+data.raw["cargo-wagon"]["cargo-wagon"].pictures={rotated={layers=helper{chars="w,w,w,w,w,w,w,w,w,w,w,w",x=6,y=2,offz=1}}}
+data.raw["corpse"]["cargo-wagon-remnants"].animation={layers=helper{chars="w,w,w,w,w,w,∅,∅,∅,∅,∅,∅",x=6,y=2,ftint={{r=1,g=0.3,b=0.5}}}}
 
 
 data.raw["fish"]["fish"].pictures={sheet={layers=helper{chars="🐟",x=1,y=1,btint={{r=0,g=0,b=0,a=0}}}}}


### PR DESCRIPTION
Fixed the last couple bugs that were bothering me in my earlier code for this and cleaned it up some.

The math for calculating sprite offsets was able to be simplified a bit, which also should make it behave more consistently for other sprite dimensions.

The `offz` parameter handles the common need to shift sprites in the y direction for something that should appear raised above the ground (rather than further north) and shifts the center of rotation with it.

For the actual rotated sprite definitions, I'm not sure whether this is the ideal way to define them, because I'm not super familiar with the options for handling split spritesheets, but this seems to work without looking too off. Also as mentioned in a few comments, some of this might be made less unwieldy with some combined sheets of glyphs in a convenient arrangement (at the expense of making references to individual glyphs slightly more work) but that's something that can be figured out later.